### PR TITLE
Disable firmware auto-inclusion and add initrd safety check

### DIFF
--- a/auto/config
+++ b/auto/config
@@ -11,8 +11,8 @@ lb config noauto \
     --archive-areas "main contrib non-free non-free-firmware" \
     --apt-recommends true \
     --apt-source-archives false \
-    --firmware-binary true \
-    --firmware-chroot true \
+    --firmware-binary false \
+    --firmware-chroot false \
     --memtest none \
     --win32-loader false \
     --iso-application "Sky1 Linux" \

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -274,6 +274,14 @@ fi
 
 echo "Kernel version: $KERNEL_VERSION"
 
+# Verify initrd exists - abort if missing (indicates broken chroot)
+if [ ! -f "$MOUNT_DIR/boot/initrd.img-$KERNEL_VERSION" ]; then
+    echo "ERROR: initrd.img-$KERNEL_VERSION not found in chroot /boot/"
+    echo "       This usually means initramfs-tools failed to install."
+    echo "       Check the build log and try a clean rebuild."
+    exit 1
+fi
+
 # Ensure DTBs are in /boot/dtbs (copy from kernel package location if needed)
 mkdir -p "$MOUNT_DIR/boot/dtbs"
 DTB_SOURCE="$MOUNT_DIR/usr/lib/linux-image-$KERNEL_VERSION/cix"


### PR DESCRIPTION
## Summary

- **Disable `--firmware-binary` and `--firmware-chroot`** in `auto/config` — `firmware-qcom-soc` in Debian sid (`20260110-1`) depends on `firmware-qcom-dsp`, causing `lb build` to fail with 1000+ unresolved dependencies (including `initramfs-tools`). Since `sky1-firmware` already provides the hardware-specific firmware for CIX Sky1 SoC, there's no need for live-build to auto-install every firmware package from Debian's `non-free-firmware` section.
- **Add initrd existence check** in `build-image.sh` — if the chroot is broken (e.g. from a failed `lb build`), `build-image.sh` would previously produce a disk image with a GRUB config referencing a non-existent `initrd.img`, resulting in an unbootable image. Now it aborts with a clear error.

## Context

When building with `./scripts/build.sh xfce developer image clean`, the build fails during `lb build` because the Debian sid package resolver cannot satisfy `firmware-qcom-soc → firmware-qcom-dsp`. The chroot ends up partially built (kernel installed but no `initramfs-tools`), and `build-image.sh` still runs because the chroot directory exists, producing a broken ~121MB image that fails at GRUB with:
```
error: fs/fshelp.c:find_file:260:file '/boot/initrd.img-6.18.8-sky1' not found.
```

## Test plan

- [ ] Clean build with `./scripts/build.sh xfce developer image clean` succeeds
- [ ] Built image has `initrd.img-*` in `/boot/`
- [ ] Image boots correctly on O6N hardware
- [ ] If initrd is artificially removed from chroot, `build-image.sh` aborts with clear error